### PR TITLE
Addresses #4: Make options keyboard accessible.

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -12,7 +12,7 @@ export default class Footer extends Component {
   render() {
     return (
       <footer>
-      	<p className="start-over"><a onClick={() => { this.handleRestart() } }>Start over</a></p>
+      	<p className="start-over"><button onClick={() => { this.handleRestart() } }>Start over</button></p>
 
 				<p className="credit"><a href="http://clarabeyer.co" target="_blank">clara fucking beyer</a> made this. she's on <a href="https://github.com/csb324" target="_blank">github</a> and <a href="https://twitter.com/clarabellum" target="_blank">twitter</a></p>
         <p className="credit">many thanks to <a href="http://jezebel.com/a-list-of-pro-women-pro-immigrant-pro-earth-anti-big-1788752078">this article</a>, from which many of these links are taken. want to add something? submit a fucking <a href="https://github.com/csb324/holyfucktheelectionistomorrow" target="_blank">pull request</a></p>

--- a/src/components/Idea.js
+++ b/src/components/Idea.js
@@ -24,6 +24,11 @@ export default class Idea extends Component {
     window.open(url, '_blank').focus();
   }
 
+  componentDidMount() {
+    // Focus on header so we can tab through options
+    document.querySelector('.idea-text').focus();
+  }
+
   renderButton(button, index) {
     let onClick;
     const key = "button-" + index;
@@ -48,7 +53,7 @@ export default class Idea extends Component {
     }
 
     return (
-      <a key={key} className={buttonClass} onClick={onClick}>{button.text}</a>
+      <button key={key} className={buttonClass} onClick={onClick}>{button.text}</button>
     )
   }
 
@@ -59,7 +64,7 @@ export default class Idea extends Component {
       buttons = this.props.links;
     }
 
-    const buttonElements = buttons.map((button, index) => {        
+    const buttonElements = buttons.map((button, index) => {
       return this.renderButton(button, index)
     })
 
@@ -89,7 +94,7 @@ export default class Idea extends Component {
     return (
       <div className="idea-container">
         <p className="idea-intro">{ pretext }</p>
-        <div className="idea-text">{ text }</div>
+        <div className="idea-text" tabIndex="-1">{ text }</div>
 
         { this.renderButtons(this.props.idea) }
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -221,6 +221,7 @@ footer {
 
   .idea-text {
     font-size: 3em;
+    outline: none;
   }
 
   .idea-buttons {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -107,6 +107,7 @@ a {
 }
 
 %button {
+  font-family: 'Biryani', sans-serif;
   padding: 0.7em 0.5em 0.5em;
   font-size: 1.5em;
   font-weight: 800;
@@ -115,14 +116,14 @@ a {
   text-align: center;
   transition: 0.2s;
   border-radius: 3px;
-
 }
 
 .idea-button {
   flex: 1 0 40%;
+  border: none;
   display: flex;
   justify-content: center;
-  align-items: center;  
+  align-items: center;
 
   @extend %button;
 
@@ -182,9 +183,11 @@ footer {
 }
 
 .start-over {
-  text-transform: uppercase;
-  a {
+
+  button {
+    text-transform: uppercase;
     display: inline-block;
+    border: none;
     @extend %button;
     background-color: #111;
     color: inherit;
@@ -214,7 +217,7 @@ footer {
 @media screen and (min-width: 501px) {
   .main-app-nav {
     font-size: 1.3em;
-  } 
+  }
 
   .idea-text {
     font-size: 3em;


### PR DESCRIPTION
- Change anchors to buttons to get native focus-ability.
- Adjust css to account for buttons, not anchors
- Focus on header on state change to keep tab index in expected spot

**To test**:
Run locally and use `tab` + `enter` to move through the options. When you hit `enter` to select an option, you should be focused on the next state's header so you can tab forward through the options. 


**note**:
I'm not super familiar with react, so it's likely there is a more "react way" to do this...  