### PR TITLE
Added Safecast links for saving the fucking earth

### DIFF
--- a/src/constants/LinkConstants.js
+++ b/src/constants/LinkConstants.js
@@ -225,6 +225,10 @@ export const LINKS_LIST = {
 				text: "LEAGUE OF CONSERVATION VOTERS",
 				link: "https://secure3.convio.net/lcv/site/Donation2?df_id=1741&1741.donation=form1"
 			}
+						{
+				text: "SAFECAST",
+				link: "http://blog.safecast.org/donate/"
+			}
 		],
 		volunteer: [
 			{
@@ -234,6 +238,10 @@ export const LINKS_LIST = {
 			{
 				text: "NEXTGEN CLIMATE ACTION",
 				link: "https://nextgenclimate.org/volunteer/"
+			}
+			{
+				text: "SAFECAST",
+				link: "http://blog.safecast.org/volunteer/"
 			}
 		]
 	}


### PR DESCRIPTION
Safecast creates public domain environmental data. Started after Fukushima meltdown and have since created the largest dataset of radiation background data ever. Now working on air quality.