### PR TITLE
Remove policy orthogonal organizations from save the fucking earth donations.

### DIFF
--- a/src/constants/LinkConstants.js
+++ b/src/constants/LinkConstants.js
@@ -210,14 +210,6 @@ export const LINKS_LIST = {
 	earth: {
 		donate: [
 			{
-				text: "EARTHJUSTICE",
-				link: "https://secure.earthjustice.org/site/Donation2?df_id=10960&10960.donation=form1&_ga=1.146521844.1974926048.1478708236"
-			},
-			{
-				text: "THE SIERRA CLUB",
-				link: "https://vault.sierraclub.org/ways-to-give/"
-			},
-			{
 				text: "CLIMATE SCIENCE LEGAL DEFENSE FUND",
 				link: "http://climatesciencedefensefund.org/donate/monthly/"
 			},


### PR DESCRIPTION
The Sierra Club and Earth Justice have historically promoted green energy
strategies and opposed nuclear power. In my opinion these organizations are
unsuitable for receiving direct contributions from individuals who have a
strong desire to reverse climate change.

I left Earth Justice in the volunteer category because informed individuals
participating directly in such an organization will have the capability to
set priorities according to their conscience.

Environmental Progress illustrates the challenge in overcoming climate change
challenges without the help of nuclear power using Germany's last decade as
an example: http://www.environmentalprogress.org/germany/

For an introduction to the pro-nuclear climate movement watch Pandora's
Promise: https://www.netflix.com/title/70267585