### PR TITLE
remove duplicating 'now what' button

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -24,12 +24,14 @@ export class App extends Component {
 
     if (choices.topic && choices.action) {
       currentLinks = links[choices.topic][choices.action];
-
-      currentLinks.push({
+      if (currentLinks[currentLinks.length - 1].text != "FUCK YEAH. NOW WHAT?") {
+        // Only push this link if it's not already in there.
+        currentLinks.push({
         text: "FUCK YEAH. NOW WHAT?",
         stepsForward: 1,
         class: "idea-button--accent"
       });
+      }
     }
 
     return (


### PR DESCRIPTION
As it turns out, this was because currentLinks.push() was being called every time, regardless of whether or not it had already been added previously. Now it checks if the last link already has "FUCK YEAH. NOW WHAT?" as its text.