### PR TITLE
Add info about paying for clean home energy

### DIFF
--- a/src/constants/LinkConstants.js
+++ b/src/constants/LinkConstants.js
@@ -244,6 +244,10 @@ export const LINKS_LIST = {
 			{
 				text: "COOL EARTH",
 				link: "https://www.coolearth.org/get-involved/donate/"
+			},
+			{
+				text: "PAY MORE FOR CLEAN ENERGY",
+				link: "https://cleanenergy.fyi"
 			}
 		],
 		volunteer: [


### PR DESCRIPTION
Adds a link to a page called [Clean Energy FYI](https://cleanenergy.fyi/) that documents how people can pay extra to get clean home energy instead of using fossil fuels.

This is not really a donation site, but the climate donation section seemed like the closest fitting section since paying for clean energy is an easy way to turn money into progress on climate issues.