### PR TITLE
start-over hover was too fucking subtle. Invert it.

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -196,7 +196,8 @@ footer {
     color: inherit;
 
     &:hover {
-      background-color: #000;
+      background-color: #fff;
+      color: #111;
     }
   }
 


### PR DESCRIPTION
When hovering over the 'start over' button, I actually couldn't see the change in background on my screen. This contributed to me having trouble finding the 'start over' button.
This change makes the hover blindingly fucking obvious.